### PR TITLE
Add investing-to-lunch-money and target-lunch-money projects

### DIFF
--- a/source/includes/_awesome_projects.md
+++ b/source/includes/_awesome_projects.md
@@ -1,15 +1,31 @@
 # Awesome Projects
 This is a list of awesome open-sourced projects created by the Lunch Money community!
 
-Description                                                        | Made by                                             | Github Link
------------                                                        | -------                                             | -----------
-JavaScript API client with TypeScript support                      | [@joehoyle](https://twitter.com/joe_hoyle)          | [Link](https://github.com/lunch-money/lunch-money-js)
-Sync Monzo transactions to Lunch Money automatically               | [@joehoyle](https://twitter.com/joe_hoyle)          | [Link](https://github.com/joehoyle/monzo-to-lunch-money)
-Sync bunq transactions to Lunch Money automatically                | [@markjongkind](https://twitter.com/markjongkind)   | [Link](https://github.com/markjongkind/bunq-to-lunchmoney)
-Sync your Delta cryptocurrency portfolio balance to Lunch Money    | [@markjongkind](https://twitter.com/markjongkind)   | [Link](https://github.com/markjongkind/delta-to-lunchmoney)
-Lunch Money React Native app (WIP)                                 | [@yuanhaochiang](https://twitter.com/yuanhaochiang) | [Link](https://github.com/yuanworks/bento-money)
-Match Amazon transactions and set transaction notes in Lunch Money | [@samwelnella](https://github.com/samwelnella)      | [Link](https://github.com/samwelnella/amazon-transactions-to-lunchmoney)
-Go API Client                                                      | [@icco](https://twitter.com/icco)                   | [Link](https://github.com/icco/lunchmoney)
+## Auto-importers
+
+Source                                                               | Made by                                             | Git repo
+-----------                                                          | -------                                             | -----------
+[Monzo](https://monzo.com) transactions                              | [@joehoyle](https://twitter.com/joe_hoyle)          | [Link](https://github.com/joehoyle/monzo-to-lunch-money)
+[bunq](https://www.bunq.com/) transactions                           | [@markjongkind](https://twitter.com/markjongkind)   | [Link](https://github.com/markjongkind/bunq-to-lunchmoney)
+[Delta](https://www.delta.exchange) cryptocurrency portfolio balance | [@markjongkind](https://twitter.com/markjongkind)   | [Link](https://github.com/markjongkind/delta-to-lunchmoney)
+[Amazon](https://amazon.com) transaction notes                       | [@samwelnella](https://github.com/samwelnella)      | [Link](https://github.com/samwelnella/amazon-transactions-to-lunchmoney)
+[Investing.com](https://investing.com) security prices               | [@DouweM](https://twitter.com/DouweM)                | [Link](https://gitlab.com/DouweM/investing-to-lunch-money)
+
+## API clients
+
+Language                           | Made by                                             | Git repo
+-----------                        | -------                                             | -----------
+JavaScript with TypeScript support | [@joehoyle](https://twitter.com/joe_hoyle)          | [Link](https://github.com/lunch-money/lunch-money-js)
+Go                                 | [@icco](https://twitter.com/icco)                   | [Link](https://github.com/icco/lunchmoney)
+
+## Other
+
+Description                                                                     | Made by                                             | Git repo
+-----------                                                                     | -------                                             | -----------
+React Native app (WIP)                                                          | [@yuanhaochiang](https://twitter.com/yuanhaochiang) | [Link](https://github.com/yuanworks/bento-money)
+[Singer](http://singer.io) target to sync asset balances from arbitrary sources | [@DouweM](https://twitter.com/DouweM)                | [Link](https://gitlab.com/DouweM/target-lunch-money)
+
+
 
 <aside class="notice">
 Did you create something with the Lunch Money API? Let us know and we'll add it to this list!


### PR DESCRIPTION
I split the Awesome Projects page up into "Auto-importers", "API clients" and "Other" categories, and added my own https://gitlab.com/DouweM/investing-to-lunch-money and https://gitlab.com/DouweM/target-lunch-money.