### PR TITLE
Fix parameters type for inserting transactions

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -152,7 +152,7 @@ Use this endpoint to insert many transactions at once.
 
 `POST https://dev.lunchmoney.app/v1/transactions`
 
-### Query Parameters
+### Body Parameters
 Parameter           | Type    | Required | Default | Description
 ---------           | ----    | -------- | ------- | -----------
 transactions        | array   | true     | -       | List of transactions to insert (see below)


### PR DESCRIPTION
If we POST an array of transactions to https://dev.lunchmoney.app/v1/transactions via query parameters, this fails. POSTing the array in the body works as expected.