### PR TITLE
Fix update transaction response description

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -182,7 +182,7 @@ Use this endpoint to update a single transaction. You may also use this to split
 
 > Example 200 Response
 >
-> Upon success, IDs of inserted transactions will be returned in an array.
+> If a split was part of the request, an array of newly-created split transactions will be returned.
 
 ```json
 {


### PR DESCRIPTION
It looks like the response description for update transaction may have been duplicated from the "Insert Transactions" response description. The adjusted response description matches the old API docs.