### PR TITLE
Fix small typo in budget json

### DIFF
--- a/source/includes/_budget.md
+++ b/source/includes/_budget.md
@@ -51,7 +51,7 @@ Use this endpoint to get full details on the budgets for all categories between 
             },
             "2020-07-01": {
                 "spending_to_base": 1720.46
-            },
+            }
         },
         "order": 0
     },


### PR DESCRIPTION
Objects can't have trailing comma on last object.