### PR TITLE
Clarify Update Transaction documentation

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -257,7 +257,7 @@ Use this endpoint to update a single transaction. You may also use this to split
 Parameter           | Type    | Required | Default | Description
 ---------           | ----    | -------- | ------- | -----------
 split               | object  | false    | -       | Defines the split of a transaction. You may not split an already-split transaction, recurring transaction, or group transaction. (see Split object below)
-transaction         | object  | true     | -       | Updates to transaction matching ID (see Update Transaction object below)
+transaction         | object  | true     | -       | The transaction update object (see Update Transaction object below). Must include an `id` matching an existing transaction.
 debit_as_negative   | boolean | false    | false   | If true, will assume negative amount values denote expenses and positive amount values denote credits. Defaults to false.
 skip_balance_update | boolean | false    | true    | If false, will skip updating balance if an asset_id is present for any of the transactions.
 


### PR DESCRIPTION
Based on my experience, the `transaction` object in the "Update Transaction" doc was simply a transaction with modifications made to several of its properties. At its core, however, it still needed the same ID so LM could associate it with the transaction in the DB. The docs originally said, "Updates to transaction matching ID" which I found hard to understand.