### PR TITLE
Fix attribute names on the user object

### DIFF
--- a/source/includes/_user.md
+++ b/source/includes/_user.md
@@ -4,9 +4,9 @@
 
 | Attribute Name | Type   | Description                                                                             |
 | -------------- | ------ | --------------------------------------------------------------------------------------- |
-| id             | number | Unique identifier for user                                                              |
-| name           | string | User's' name                                                                            |
-| email          | string | User's email                                                                            |
+| user_id        | number | Unique identifier for user                                                              |
+| user_name      | string | User's' name                                                                            |
+| user_email     | string | User's email                                                                            |
 | account_id     | number | Unique identifier for the associated budgeting account                                  |
 | budget_name    | string | Name of the associated budgeting account                                                |
 | api_key_label  | string | User-defined label of the developer API key used. Returns null if nothing has been set. |


### PR DESCRIPTION
The first three attributes are missing the `user_` prepended on their names. The example had it correct, it was just listed incorrectly in the body.

Looks like this was previously fixed in https://github.com/lunch-money/developers/pull/22 but was then reverted back to the incorrect version in:
https://github.com/lunch-money/developers/commit/6415d51a56554e6874328b015333c4b29d539ff6