### PR TITLE
add nullable fields to Plaid Accounts object

### DIFF
--- a/source/includes/_plaid_accounts.md
+++ b/source/includes/_plaid_accounts.md
@@ -2,24 +2,25 @@
 
 ## Plaid Accounts Object
 
-Attribute Name               | Type   | Description
----------------------------- | ------ | --------------------------------------------------------------------------------
-id                           | number | Unique identifier of Plaid account
-date_linked                  | string | Date account was first linked in ISO 8601 extended format
-name                         | string | Name of the account. Can be overridden by the user. Field is originally set by Plaid
-type                         | string | Primary type of account. Typically one of:<br><ul> <li>credit</li> <li>depository</li> <li>brokerage</li> <li>cash</li> <li>loan</li> <li>Investment</li><ul><br> This field is set by Plaid and cannot be altered
-subtype                      | string | Optional subtype name of account. This field is set by Plaid and cannot be altered
-mask                         | string | Mask (last 3 to 4 digits of account) of account. This field is set by Plaid and cannot be altered
-institution_name             | string | Name of institution associated with account. This field is set by Plaid and cannot be altered
-status                       | string | Denotes the current status of the account within Lunch Money. Must be one of:<br><ul> <li>active: Account is active and in good state</li> <li>inactive: Account marked inactive from user. No transactions fetched or balance update for this account.</li> <li>relink: Account needs to be relinked with Plaid.</li> <li>syncing: Account is awaiting first import of transactions</li> <li>error: Account is in error with Plaid</li> <li>not found: Account is in error with Plaid</li> <li>not supported: Account is in error with Plaid</li><ul>
-balance                      | string | Current balance of the account in numeric format to 4 decimal places. This field is set by Plaid and cannot be altered
-currency                     | string | Currency of account balance in ISO 4217 format. This field is set by Plaid and cannot be altered
-balance_last_update          | string | Date balance was last updated in ISO 8601 extended format. This field is set by Plaid and cannot be altered
-limit                        | number | Optional credit limit of the account. This field is set by Plaid and cannot be altered
-import_start_date            | string | Date of earliest date allowed for importing transactions. Transactions earlier than this date are not imported.
-last_import                  | string | Timestamp in ISO 8601 extended format of the last time Lunch Money imported new data from Plaid for this account.
-last_fetch                   | string | Timestamp in ISO 8601 extended format of the last successful check from Lunch Money for updated data or timestamps from Plaid in ISO 8601 extended format (not necessarily date of last successful import)
-plaid_last_successful_update | string | Timestamp in ISO 8601 extended format of the last time Plaid successfully connected with institution for new transaction updates, regardless of whether any new data was available in the update.
+Attribute Name                | Type   | Nullable | Description
+----------------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------
+id                            | number | false    | Unique identifier of Plaid account
+date_linked                   | string | false    | Date account was first linked in ISO 8601 format
+name                          | string | false    | Name of the account. Can be overridden by the user. Field is originally set by Plaid
+display_name                  | string | false    | Display name of the account, if not set it will return an empty string.
+type                          | string | false    | Primary type of account. Typically one of:<br><ul> <li>credit</li> <li>depository</li> <li>brokerage</li> <li>cash</li> <li>loan</li> <li>Investment</li><ul><br> This field is set by Plaid and cannot be altered
+subtype                       | string | true     | Optional subtype name of account. This field is set by Plaid and cannot be altered
+mask                          | string | false    | Mask (last 3 to 4 digits of account) of account. This field is set by Plaid and cannot be altered
+institution_name              | string | false    | Name of institution associated with account. This field is set by Plaid and cannot be altered
+status                        | string | false    | Denotes the current status of the account within Lunch Money. Must be one of:<br><ul> <li>active: Account is active and in good state</li> <li>inactive: Account marked inactive from user. No transactions fetched or balance update for this account.</li> <li>relink: Account needs to be relinked with Plaid.</li> <li>syncing: Account is awaiting first import of transactions</li> <li>error: Account is in error with Plaid</li> <li>not found: Account is in error with Plaid</li> <li>not supported: Account is in error with Plaid</li><ul>
+balance                       | string | false    | Current balance of the account in numeric format to 4 decimal places. This field is set by Plaid and cannot be altered
+currency                      | string | false    | Currency of account balance in ISO 4217 format. This field is set by Plaid and cannot be altered
+balance_last_update           | string | false    | Date balance was last updated in ISO 8601 extended format. This field is set by Plaid and cannot be altered
+limit                         | number | true     | Optional credit limit of the account. This field is set by Plaid and cannot be altered
+import_start_date             | string | true     | Date of earliest date allowed for importing transactions. Transactions earlier than this date are not imported.
+last_import                   | string | true     | Timestamp in ISO 8601 extended format of the last time Lunch Money imported new data from Plaid for this account.
+last_fetch                    | string | true     | Timestamp in ISO 8601 extended format of the last successful check from Lunch Money for updated data or timestamps from Plaid in ISO 8601 extended format (not necessarily date of last successful import)
+plaid_last_successful_update  | string | false    | Timestamp in ISO 8601 extended format of the last time Plaid successfully connected with institution for new transaction updates, regardless of whether any new data was available in the update.
 
 ## Get All Plaid Accounts
 
@@ -32,36 +33,38 @@ Use this endpoint to get a list of all synced Plaid accounts associated with the
   "plaid_accounts": [
     {
       "id": 91,
-      "date_linked": "2020-01-28T14:15:09.111Z",
+      "date_linked": "2020-01-28",
       "name": "401k",
+      "display_name": "",
       "type": "brokerage",
       "subtype": "401k",
       "mask": "7468",
       "institution_name": "Vanguard",
       "status": "inactive",
-      "limit": null
+      "limit": null,
       "balance": "12345.6700",
       "currency": "usd",
-      "import_start_date": "2023-01-01",
       "balance_last_update": "2020-01-27T01:38:11.862Z",
+      "import_start_date": "2023-01-01",
       "last_import": "2019-09-04T12:57:09.190Z",
       "last_fetch": "2020-01-28T01:38:11.862Z",
       "plaid_last_successful_update": "2020-01-27T01:38:11.862Z",
     },
     {
       "id": 89,
-      "date_linked": "2020-01-28T14:15:09.111Z",
+      "date_linked": "2020-01-28",
       "name": "Freedom",
+      "display_name": "Freedom Card",
       "type": "credit",
       "subtype": "credit card",
       "mask": "1973",
       "institution_name": "Chase",
       "status": "active",
-      "limit": 15000
+      "limit": 15000,
       "balance": "0.0000",
       "currency": "usd",
-      "import_start_date": "2023-01-01",
       "balance_last_update": "2023-01-27T01:38:07.460Z",
+      "import_start_date": "2023-01-01",
       "last_import": "2023-01-24T12:57:03.250Z",
       "last_fetch": "2023-01-28T01:38:11.862Z",
       "plaid_last_successful_update": "2023-01-27T01:38:11.862Z",

--- a/source/includes/_plaid_accounts.md
+++ b/source/includes/_plaid_accounts.md
@@ -7,7 +7,7 @@ Attribute Name                | Type   | Nullable | Description
 id                            | number | false    | Unique identifier of Plaid account
 date_linked                   | string | false    | Date account was first linked in ISO 8601 format
 name                          | string | false    | Name of the account. Can be overridden by the user. Field is originally set by Plaid
-display_name                  | string | false    | Display name of the account, if not set it will return an empty string.
+display_name                  | string | false    | Display name of the account, if not set it will return a concatenated string of institution and account name.
 type                          | string | false    | Primary type of account. Typically one of:<br><ul> <li>credit</li> <li>depository</li> <li>brokerage</li> <li>cash</li> <li>loan</li> <li>Investment</li><ul><br> This field is set by Plaid and cannot be altered
 subtype                       | string | true     | Optional subtype name of account. This field is set by Plaid and cannot be altered
 mask                          | string | false    | Mask (last 3 to 4 digits of account) of account. This field is set by Plaid and cannot be altered

--- a/source/includes/_plaid_accounts.md
+++ b/source/includes/_plaid_accounts.md
@@ -3,7 +3,7 @@
 ## Plaid Accounts Object
 
 Attribute Name                | Type   | Nullable | Description
------------------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------
+----------------------------- | ------ | -------- | --------------------------------------------------------------------
 id                            | number | false    | Unique identifier of Plaid account
 date_linked                   | string | false    | Date account was first linked in ISO 8601 format
 name                          | string | false    | Name of the account. Can be overridden by the user. Field is originally set by Plaid


### PR DESCRIPTION
More work toward https://github.com/lunch-money/developers/issues/29. The main purpose of this PR is to add a nullable column to the plaid accounts object table, denoting which fields are nullable. With this change comes some other small improvements I noticed while in here:

1. The amount of extra spaces added to the description column of each field  to accommodate the longest description had gotten out of hand and was ironically making things harder to read in an IDE. Since the beginning and end `|` in a markdown column are optional, I've removed these to avoid the issue and clean things up (this is really just an editing change though and doesn't display differently to the user).
2. `date_linked` was documented as returning `ISO 8601 extended format` but it actually returns the regular ISO 8601 format, I've updated the description and the example.
3. `display_name` was added to the examples
4. `limit` fields in the example now have a comma at the end of their line to make them valid json
5. A few fields were reordered to match the order of a real return