### PR TITLE
add nullable column to transactions and small fixes

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -2,63 +2,62 @@
 
 ## Transaction Object
 
-| Attribute Name             | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| id                         | number  | Unique identifier for transaction                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| date                       | string  | Date of transaction in ISO 8601 format                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| payee                      | string  | Name of payee. If recurring_id is not null, this field will show the payee of associated recurring expense instead of the original transaction payee                                                                                                                                                                                                                                                                                                                                       |
-| amount                     | string  | Amount of the transaction in numeric format to 4 decimal places                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| currency                   | string  | Three-letter lowercase currency code of the transaction in ISO 4217 format                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| to_base                    | number  | The amount converted to the user's primary currency. If the multicurrency feature is not being used, to_base and amount will be the same.                                                                                                                                                                                                                                                                                                                                                  |
-| category_id                | number  | Unique identifier of associated category (see Categories)                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| category_name              | string  | Name of category associated with transaction                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| category_group_id          | number  | Unique identifier of associated category group, if any                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| category_group_name        | string  | Name of category group associated with transaction, if any                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| is_income                  | boolean | Based on the associated category's property, denotes if transaction is treated as income                                                                                                                                                                                                                                                                                                                                                                                                   |
-| exclude_from_budget        | boolean | Based on the associated category's property, denotes if transaction is excluded from budget                                                                                                                                                                                                                                                                                                                                                                                                |
-| exclude_from_totals        | boolean | Based on the associated category's property, denotes if transaction is excluded from totals                                                                                                                                                                                                                                                                                                                                                                                                |
-| created_at                 | string  | The date and time of when the transaction was created (in the ISO 8601 extended format).                                                                                                                                                                                                                                                                                                                                                                                                   |
-|                            |
-| updated_at                 | string  | The date and time of when the transaction was last updated (in the ISO 8601 extended format).                                                                                                                                                                                                                                                                                                                                                                                              |
-|                            |
-| status                     | string  | One of the following: <ul> <li>cleared: User has reviewed the transaction</li><li>uncleared: User has not yet reviewed the transaction</li><li>recurring: Transaction is linked to a recurring expense</li><li>recurring_suggested: Transaction is listed as a suggested transaction for an existing recurring expense.</li><li>pending: Imported transaction is marked as pending. This should be a temporary state.</li></ul> User intervention is required to change this to recurring. |
-| is_pending                 | boolean | Denotes if transaction is pending (not posted)                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| notes                      | string  | User-entered transaction notes If recurring_id is not null, this field will be description of associated recurring expense                                                                                                                                                                                                                                                                                                                                                                 |
-| original_name              | string  | The transactions original name before any payee name updates. For synced transactions, this is the raw original payee name from your bank.                                                                                                                                                                                                                                                                                                                                                 |
-| recurring_id               | number  | Unique identifier of associated recurring item                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| recurring_payee            | number  | Payee name of associated recurring item                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| recurring_description      | number  | Description of associated recurring item                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| recurring_cadence          | number  | Cadence of associated recurring item (one of `once a week`, `every 2 weeks`, `twice a month`, `monthly`, `every 2 months`, `every 3 months`, `every 4 months`, `twice a year`, `yearly`)                                                                                                                                                                                                                                                                                                   |
-| recurring_type             | number  | Type of associated recurring (one of `cleared`, `suggested`, `dismissed`)                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| recurring_amount           | number  | Amount of associated recurring item                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| recurring_currency         | number  | Currency of associated recurring item                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| parent_id                  | number  | Exists if this is a split transaction. Denotes the transaction ID of the original transaction. Note that the parent transaction is not returned in this call.                                                                                                                                                                                                                                                                                                                              |
-| has_children               | boolean | True if this transaction is a parent transaction and is split into 2 or more other transactions                                                                                                                                                                                                                                                                                                                                                                                            |
-| group_id                   | number  | Exists if this transaction is part of a group. Denotes the parent’s transaction ID                                                                                                                                                                                                                                                                                                                                                                                                         |
-| is_group                   | boolean | True if this transaction represents a group of transactions. If so, amount and currency represent the totalled amount of transactions bearing this transaction’s id as their group_id. Amount is calculated based on the user’s primary currency.                                                                                                                                                                                                                                          |
-| asset_id                   | number  | Unique identifier of associated manually-managed account (see Assets) Note: plaid_account_id and asset_id cannot both exist for a transaction                                                                                                                                                                                                                                                                                                                                              |
-| asset_institution_name     | number  | Institution name of associated manually-managed account                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| asset_name                 | number  | Name of associated manually-managed account                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| asset_display_name         | number  | Display name of associated manually-managed account                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| asset_status               | number  | Status of associated manually-managed account (one of `active`, `closed`)                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| plaid_account_id           | number  | Unique identifier of associated Plaid account (see Plaid Accounts) Note: plaid_account_id and asset_id cannot both exist for a transaction                                                                                                                                                                                                                                                                                                                                                 |
-| plaid_account_name         | number  | Name of associated Plaid account                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| plaid_account_mask         | number  | Mask of associated Plaid account                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| institution_name           | number  | Institution name of associated Plaid account                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| plaid_account_display_name | number  | Display name of associated Plaid account                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| plaid_metadata             | number  | Metadata associated with imported transaction from Plaid                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| source                     | number  | Source of the transaction (one of `api`, `csv`, `manual`,`merge`,`plaid`,`recurring`,`rule`,`user`)                                                                                                                                                                                                                                                                                                                                                                                        |
-| display_name               | number  | Display name for payee for transaction based on whether or not it is linked to a recurring item. If linked, returns `recurring_payee` field. Otherwise, returns the `payee` field.                                                                                                                                                                                                                                                                                                         |
-| display_notes              | number  | Display notes for transaction based on whether or not it is linked to a recurring item. If linked, returns `recurring_notes` field. Otherwise, returns the `notes` field.                                                                                                                                                                                                                                                                                                                  |
-| account_display_name       | number  | Display name for associated account (manual or Plaid). If this is a synced account, returns `plaid_account_display_name` or `asset_display_name`.                                                                                                                                                                                                                                                                                                                                          |
-| tags                       | Tag[]   | Array of Tag objects                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| external_id                | string  | User-defined external ID for any manually-entered or imported transaction. External ID cannot be accessed or changed for Plaid-imported transactions. External ID must be unique by asset_id. Max 75 characters.                                                                                                                                                                                                                                                                           |
-| original_date              | string  | DEPRECATED                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| type                       | string  | DEPRECATED                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| subtype                    | string  | DEPRECATED                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| fees                       | string  | DEPRECATED                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| price                      | string  | DEPRECATED                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| quantity                   | string  | DEPRECATED                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+Attribute Name             | Type    | Nullable | Description
+-------------------------- | ------- | -------- | ----------------------------------------------------------------------
+id                         | number  | false    | Unique identifier for transaction
+date                       | string  | false    | Date of transaction in ISO 8601 format
+payee                      | string  | false    | Name of payee. If recurring_id is not null, this field will show the payee of associated recurring expense instead of the original transaction payee
+amount                     | string  | false    | Amount of the transaction in numeric format to 4 decimal places
+currency                   | string  | false    | Three-letter lowercase currency code of the transaction in ISO 4217 format
+to_base                    | number  | false    | The amount converted to the user's primary currency. If the multicurrency feature is not being used, to_base and amount will be the same.
+category_id                | number  | true     | Unique identifier of associated category (see Categories)
+category_name              | string  | true     | Name of category associated with transaction
+category_group_id          | number  | true     | Unique identifier of associated category group, if any
+category_group_name        | string  | true     | Name of category group associated with transaction, if any
+is_income                  | boolean | false    | Based on the associated category's property, denotes if transaction is treated as income
+exclude_from_budget        | boolean | false    | Based on the associated category's property, denotes if transaction is excluded from budget
+exclude_from_totals        | boolean | false    | Based on the associated category's property, denotes if transaction is excluded from totals
+created_at                 | string  | false    | The date and time of when the transaction was created (in the ISO 8601 extended format).
+updated_at                 | string  | false    | The date and time of when the transaction was last updated (in the ISO 8601 extended format).
+status                     | string  | true     | One of the following: <ul> <li>cleared: User has reviewed the transaction</li><li>uncleared: User has not yet reviewed the transaction</li><li>recurring: Transaction is linked to a recurring expense</li><li>recurring_suggested: Transaction is listed as a suggested transaction for an existing recurring expense.</li><li>pending: Imported transaction is marked as pending. This should be a temporary state.</li></ul> User intervention is required to change this to recurring.
+is_pending                 | boolean | false    | Denotes if transaction is pending (not posted)
+notes                      | string  | true     | User-entered transaction notes If recurring_id is not null, this field will be description of associated recurring expense                                                                                                                                                                                                                                                                                                                                                                 |
+original_name              | string  | true     | The transactions original name before any payee name updates. For synced transactions, this is the raw original payee name from your bank.                                                                                                                                                                                                                                                                                                                                                 |
+recurring_id               | number  | true     | Unique identifier of associated recurring item
+recurring_payee            | number  | true     | Payee name of associated recurring item
+recurring_description      | number  | true     | Description of associated recurring item
+recurring_cadence          | number  | true     | Cadence of associated recurring item (one of `once a week`, `every 2 weeks`, `twice a month`, `monthly`, `every 2 months`, `every 3 months`, `every 4 months`, `twice a year`, `yearly`)
+recurring_type             | number  | true     | Type of associated recurring (one of `cleared`, `suggested`, `dismissed`)
+recurring_amount           | number  | true     | Amount of associated recurring item
+recurring_currency         | number  | true     | Currency of associated recurring item
+parent_id                  | number  | true     | Exists if this is a split transaction. Denotes the transaction ID of the original transaction. Note that the parent transaction is not returned in this call.
+has_children               | boolean | false    | True if this transaction is a parent transaction and is split into 2 or more other transactions
+group_id                   | number  | true     | Exists if this transaction is part of a group. Denotes the parent’s transaction ID
+is_group                   | boolean | false    | True if this transaction represents a group of transactions. If so, amount and currency represent the totalled amount of transactions bearing this transaction’s id as their group_id. Amount is calculated based on the user’s primary currency.
+asset_id                   | number  | true     | Unique identifier of associated manually-managed account (see Assets) Note: plaid_account_id and asset_id cannot both exist for a transaction
+asset_institution_name     | number  | true     | Institution name of associated manually-managed account
+asset_name                 | number  | true     | Name of associated manually-managed account
+asset_display_name         | number  | true     | Display name of associated manually-managed account
+asset_status               | number  | true     | Status of associated manually-managed account (one of `active`, `closed`)
+plaid_account_id           | number  | true     | Unique identifier of associated Plaid account (see Plaid Accounts) Note: plaid_account_id and asset_id cannot both exist for a transaction
+plaid_account_name         | number  | true     | Name of associated Plaid account
+plaid_account_mask         | number  | true     | Mask of associated Plaid account
+institution_name           | number  | true     | Institution name of associated Plaid account
+plaid_account_display_name | number  | true     | Display name of associated Plaid account
+plaid_metadata             | number  | true     | Metadata associated with imported transaction from Plaid
+source                     | number  | false    | Source of the transaction (one of `api`, `csv`, `manual`,`merge`,`plaid`,`recurring`,`rule`,`user`)
+display_name               | number  | false    | Display name for payee for transaction based on whether or not it is linked to a recurring item. If linked, returns `recurring_payee` field. Otherwise, returns the `payee` field.
+display_notes              | number  | true     | Display notes for transaction based on whether or not it is linked to a recurring item. If linked, returns `recurring_notes` field. Otherwise, returns the `notes` field.
+account_display_name       | number  | false    | Display name for associated account (manual or Plaid). If this is a synced account, returns `plaid_account_display_name` or `asset_display_name`.
+tags                       | Tag[]   | false    | Array of Tag objects
+children                   | Transaction[] | true     | Array of child Transaction objections, these objects are slimmed down to the more essential fields, and contain an extra field called `formatted_date` that contains the date of transaction in ISO 8601 format
+external_id                | string  | true     | User-defined external ID for any manually-entered or imported transaction. External ID cannot be accessed or changed for Plaid-imported transactions. External ID must be unique by asset_id. Max 75 characters.
+original_date              | string  | true     | DEPRECATED
+type                       | string  | true     | DEPRECATED
+subtype                    | string  | true     | DEPRECATED
+fees                       | string  | true     | DEPRECATED
+price                      | string  | true     | DEPRECATED
+quantity                   | string  | true     | DEPRECATED
 
 ## Get All Transactions
 
@@ -97,7 +96,7 @@ Use this endpoint to retrieve all transactions between a date range.
       "recurring_amount": null,
       "recurring_currency": null,
       "parent_id": 225508713,
-      "has_children": null,
+      "has_children": false,
       "group_id": null,
       "is_group": false,
       "asset_id": null,
@@ -116,7 +115,12 @@ Use this endpoint to retrieve all transactions between a date range.
       "display_name": "Amazon",
       "display_notes": null,
       "account_display_name": "Amazon Whole Foods Visa",
-      "tags": [],
+      "tags": [
+        {
+          "name": "Amazon",
+          "id": 76543
+        }
+      ],
       "external_id": null
     },
     {
@@ -147,9 +151,9 @@ Use this endpoint to retrieve all transactions between a date range.
       "recurring_amount": null,
       "recurring_currency": null,
       "parent_id": 225588844,
-      "has_children": null,
+      "has_children": false,
       "group_id": null,
-      "is_group": false,
+      "is_group": true,
       "asset_id": null,
       "asset_institution_name": null,
       "asset_name": null,
@@ -167,6 +171,32 @@ Use this endpoint to retrieve all transactions between a date range.
       "display_notes": null,
       "account_display_name": "Amex Plat",
       "tags": [],
+      "children": [
+        {
+          "id": 246946948,
+          "payee": "Child Transaction One",
+          "amount": "-33.6000",
+          "currency": "cad",
+          "date": "2023-08-10",
+          "formatted_date": "2023-09-10",
+          "notes": null,
+          "asset_id": 7409,
+          "plaid_account_id": null,
+          "to_base": -33.6
+        },
+        {
+          "id": 246946948,
+          "payee": "Child Transaction Two",
+          "amount": "-33.6000",
+          "currency": "cad",
+          "date": "2023-08-10",
+          "formatted_date": "2023-09-10",
+          "notes": null,
+          "asset_id": 7409,
+          "plaid_account_id": null,
+          "to_base": -33.6
+        }
+      ]
       "external_id": null
     }
   ],
@@ -188,22 +218,22 @@ Returns list of Transaction objects and a `has_more` indicator. If no query para
 
 ### Query Parameters
 
-| Parameter         | Type    | Required | Default | Description                                                                                                                                                  |
-| ----------------- | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| tag_id            | number  | false    | -       | Filter by tag. Only accepts IDs, not names.                                                                                                                  |
-| recurring_id      | number  | false    | -       | Filter by recurring expense                                                                                                                                  |
-| plaid_account_id  | number  | false    | -       | Filter by Plaid account                                                                                                                                      |
-| category_id       | number  | false    | -       | Filter by category. Will also match category groups.                                                                                                         |
-| asset_id          | number  | false    | -       | Filter by asset                                                                                                                                              |
-| is_group          | boolean | false    | -       | Filter by group (returns transaction groups)                                                                                                                 |
-| status            | string  | false    | -       | Filter by status (Can be `cleared` or `uncleared`. For recurring transactions, use `recurring`)                                                              |
-| start_date        | string  | false    | -       | Denotes the beginning of the time period to fetch transactions for. Defaults to beginning of current month. Required if end_date exists. Format: YYYY-MM-DD. |
-| end_date          | string  | false    | -       | Denotes the end of the time period you'd like to get transactions for. Defaults to end of current month. Required if start_date exists. Format: YYYY-MM-DD.  |
-| debit_as_negative | boolean | false    | false   | Pass in true if you’d like expenses to be returned as negative amounts and credits as positive amounts. Defaults to false.                                   |
-| pending           | boolean | false    | false   | Pass in true if you’d like to include imported transactions with a pending status.                                                                           |
-| offset            | number  | false    | -       | Sets the offset for the records returned                                                                                                                     |
-| limit             | number  | false    | 1000    | Sets the maximum number of records to return.                                                                                                                |
-| group_id          | number  | false    | -       | DEPRECATED (Use [GET /v1/transactions-group](#get-transaction-group) instead)                                                                                |
+Parameter         | Type    | Required | Default | Description
+----------------- | ------- | -------- | ------- | ---------------------------------------------------------------------
+tag_id            | number  | false    | -       | Filter by tag. Only accepts IDs, not names.
+recurring_id      | number  | false    | -       | Filter by recurring expense
+plaid_account_id  | number  | false    | -       | Filter by Plaid account
+category_id       | number  | false    | -       | Filter by category. Will also match category groups.
+asset_id          | number  | false    | -       | Filter by asset
+is_group          | boolean | false    | -       | Filter by group (returns transaction groups)
+status            | string  | false    | -       | Filter by status (Can be `cleared` or `uncleared`. For recurring transactions, use `recurring`)
+start_date        | string  | false    | -       | Denotes the beginning of the time period to fetch transactions for. Defaults to beginning of current month. Required if end_date exists. Format: YYYY-MM-DD.
+end_date          | string  | false    | -       | Denotes the end of the time period you'd like to get transactions for. Defaults to end of current month. Required if start_date exists. Format: YYYY-MM-DD.
+debit_as_negative | boolean | false    | false   | Pass in true if you’d like expenses to be returned as negative amounts and credits as positive amounts. Defaults to false.
+pending           | boolean | false    | false   | Pass in true if you’d like to include imported transactions with a pending status.
+offset            | number  | false    | -       | Sets the offset for the records returned
+limit             | number  | false    | 1000    | Sets the maximum number of records to return.
+group_id          | number  | false    | -       | DEPRECATED (Use [GET /v1/transactions-group](#get-transaction-group) instead)
 
 ## Get Single Transaction
 
@@ -278,9 +308,9 @@ Returns a single Transaction object
 
 ### Query Parameters
 
-| Parameter         | Type    | Required | Default | Description                                                                                                                |
-| ----------------- | ------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| debit_as_negative | boolean | false    | false   | Pass in true if you’d like expenses to be returned as negative amounts and credits as positive amounts. Defaults to false. |
+Parameter         | Type    | Required | Default | Description
+----------------- | ------- | -------- | ------- | ---------------------------------------------------------------------
+debit_as_negative | boolean | false    | false   | Pass in true if you’d like expenses to be returned as negative amounts and credits as positive amounts. Defaults to false.
 
 ## Insert Transactions
 
@@ -316,30 +346,30 @@ Use this endpoint to insert many transactions at once.
 
 ### Body Parameters
 
-| Parameter           | Type    | Required | Default | Description                                                                                                                                                      |
-| ------------------- | ------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| transactions        | array   | true     | -       | List of transactions to insert (see below)                                                                                                                       |
-| apply_rules         | boolean | false    | false   | If true, will apply account’s existing rules to the inserted transactions. Defaults to false.                                                                    |
-| skip_duplicates     | boolean | false    | false   | If true, the system will automatically dedupe based on transaction date, payee and amount. Note that deduping by external_id will occur regardless of this flag. |
-| check_for_recurring | boolean | false    | false   | If true, will check new transactions for occurrences of new monthly expenses. Defaults to false.                                                                 |
-| debit_as_negative   | boolean | false    | false   | If true, will assume negative amount values denote expenses and positive amount values denote credits. Defaults to false.                                        |
-| skip_balance_update | boolean | false    | true    | If true, will skip updating balance if an asset_id is present for any of the transactions.                                                                       |
+Parameter           | Type    | Required | Default | Description
+------------------- | ------- | -------- | ------- | -------------------------------------------------------------------
+transactions        | array   | true     | -       | List of transactions to insert (see below)
+apply_rules         | boolean | false    | false   | If true, will apply account’s existing rules to the inserted transactions. Defaults to false.
+skip_duplicates     | boolean | false    | false   | If true, the system will automatically dedupe based on transaction date, payee and amount. Note that deduping by external_id will occur regardless of this flag.
+check_for_recurring | boolean | false    | false   | If true, will check new transactions for occurrences of new monthly expenses. Defaults to false.
+debit_as_negative   | boolean | false    | false   | If true, will assume negative amount values denote expenses and positive amount values denote credits. Defaults to false.
+skip_balance_update | boolean | false    | true    | If true, will skip updating balance if an asset_id is present for any of the transactions.
 
 ### Transaction Object to Insert
 
-| Key          | Type                            | Required | Description                                                                                                                                                                                                                 |
-| ------------ | ------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| date         | string                          | true     | Must be in ISO 8601 format (YYYY-MM-DD).                                                                                                                                                                                    |
-| amount       | number/string                   | true     | Numeric value of amount. i.e. $4.25 should be denoted as 4.25.                                                                                                                                                              |
-| category_id  | number                          | false    | Unique identifier for associated category_id. Category must be associated with the same account and must not be a category group.                                                                                           |
-| payee        | string                          | false    | Max 140 characters                                                                                                                                                                                                          |
-| currency     | string                          | false    | Three-letter lowercase currency code in ISO 4217 format. The code sent must exist in our database. Defaults to user account's primary currency.                                                                             |
-| asset_id     | number                          | false    | Unique identifier for associated asset (manually-managed account). Asset must be associated with the same account.                                                                                                          |
-| recurring_id | number                          | false    | Unique identifier for associated recurring expense. Recurring expense must be associated with the same account.                                                                                                             |
-| notes        | string                          | false    | Max 350 characters                                                                                                                                                                                                          |
-| status       | string                          | false    | Must be either cleared or uncleared. If recurring_id is provided, the status will automatically be set to recurring or recurring_suggested depending on the type of recurring_id. Defaults to uncleared.                    |
-| external_id  | string                          | false    | User-defined external ID for transaction. Max 75 characters. External IDs must be unique within the same asset_id.                                                                                                          |
-| tags         | Array of numbers and/or strings | false    | Passing in a number will attempt to match by ID. If no matching tag ID is found, an error will be thrown. Passing in a string will attempt to match by string. If no matching tag name is found, a new tag will be created. |
+Key          | Type                            | Required | Description
+------------ | ------------------------------- | -------- | ------------------------------------------------------------
+date         | string                          | true     | Must be in ISO 8601 format (YYYY-MM-DD).
+amount       | number/string                   | true     | Numeric value of amount. i.e. $4.25 should be denoted as 4.25.
+category_id  | number                          | false    | Unique identifier for associated category_id. Category must be associated with the same account and must not be a category group.
+payee        | string                          | false    | Max 140 characters
+currency     | string                          | false    | Three-letter lowercase currency code in ISO 4217 format. The code sent must exist in our database. Defaults to user account's primary currency.
+asset_id     | number                          | false    | Unique identifier for associated asset (manually-managed account). Asset must be associated with the same account.
+recurring_id | number                          | false    | Unique identifier for associated recurring expense. Recurring expense must be associated with the same account.
+notes        | string                          | false    | Max 350 characters
+status       | string                          | false    | Must be either cleared or uncleared. If recurring_id is provided, the status will automatically be set to recurring or recurring_suggested depending on the type of recurring_id. Defaults to uncleared.
+external_id  | string                          | false    | User-defined external ID for transaction. Max 75 characters. External IDs must be unique within the same asset_id.
+tags         | Array of numbers and/or strings | false    | Passing in a number will attempt to match by ID. If no matching tag ID is found, an error will be thrown. Passing in a string will attempt to match by string. If no matching tag name is found, a new tag will be created.
 
 ## Update Transaction
 
@@ -379,38 +409,38 @@ Use this endpoint to update a single transaction. You may also use this to split
 
 ### Body Parameters
 
-| Parameter           | Type    | Required | Default | Description                                                                                                                                               |
-| ------------------- | ------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| split               | object  | false    | -       | Defines the split of a transaction. You may not split an already-split transaction, recurring transaction, or group transaction. (see Split object below) |
-| transaction         | object  | true     | -       | The transaction update object (see Update Transaction object below). Must include an `id` matching an existing transaction.                               |
-| debit_as_negative   | boolean | false    | false   | If true, will assume negative amount values denote expenses and positive amount values denote credits. Defaults to false.                                 |
-| skip_balance_update | boolean | false    | true    | If false, will skip updating balance if an asset_id is present for any of the transactions.                                                               |
+Parameter           | Type    | Required | Default | Description
+------------------- | ------- | -------- | ------- | -------------------------------------------------------------------
+split               | Split[] | see description | -       | Defines the split of a transaction. You may not split an already-split transaction, recurring transaction, or group transaction. (see Split object below). If passing an array of split objects to this parameter, the transaction parameter is not required.
+transaction         | object  | see description | -       | The transaction update object (see Update Transaction object below). Must include an `id` matching an existing transaction. If passing a transaction object to this parameter, the split parameter is not required.
+debit_as_negative   | boolean | false    | false   | If true, will assume negative amount values denote expenses and positive amount values denote credits. Defaults to false.
+skip_balance_update | boolean | false    | true    | If false, will skip updating balance if an asset_id is present for any of the transactions.
 
 ### Update Transaction Object
 
-| Key          | Type                            | Description                                                                                                                                                                                                                                                                                                     |
-| ------------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| date         | string                          | Must be in ISO 8601 format (YYYY-MM-DD).                                                                                                                                                                                                                                                                        |
-| category_id  | number                          | Unique identifier for associated category_id. Category must be associated with the same account and must not be a category group.                                                                                                                                                                               |
-| payee        | string                          | Max 140 characters                                                                                                                                                                                                                                                                                              |
-| amount       | number or string                | You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id                                                                                                                                                       |
-| currency     | string                          | You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id. Defaults to user account's primary currency.                                                                                                         |
-| asset_id     | number                          | Unique identifier for associated asset (manually-managed account). Asset must be associated with the same account. You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id                                    |
-| recurring_id | number                          | Unique identifier for associated recurring expense. Recurring expense must be associated with the same account.                                                                                                                                                                                                 |
-| notes        | string                          | Max 350 characters                                                                                                                                                                                                                                                                                              |
-| status       | string                          | Must be either cleared or uncleared. Defaults to uncleared If recurring_id is provided, the status will automatically be set to recurring or recurring_suggested depending on the type of recurring_id. Defaults to uncleared.                                                                                  |
-| external_id  | string                          | User-defined external ID for transaction. Max 75 characters. External IDs must be unique within the same asset_id. You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id                                    |
-| tags         | array of numbers and/or strings | Input must be an array, or error will be thrown. Passing in a number will attempt to match by ID. If no matching tag ID is found, an error will be thrown. Passing in a string will attempt to match by string. If no matching tag name is found, a new tag will be created. Pass in `null` to remove all tags. |
+Key          | Type                            | Description
+------------ | ------------------------------- | -----------------------------------------------------------------------
+date         | string                          | Must be in ISO 8601 format (YYYY-MM-DD).
+category_id  | number                          | Unique identifier for associated category_id. Category must be associated with the same account and must not be a category group.
+payee        | string                          | Max 140 characters
+amount       | number or string                | You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id
+currency     | string                          | You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id. Defaults to user account's primary currency.
+asset_id     | number                          | Unique identifier for associated asset (manually-managed account). Asset must be associated with the same account. You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id
+recurring_id | number                          | Unique identifier for associated recurring expense. Recurring expense must be associated with the same account.
+notes        | string                          | Max 350 characters
+status       | string                          | Must be either cleared or uncleared. Defaults to uncleared If recurring_id is provided, the status will automatically be set to recurring or recurring_suggested depending on the type of recurring_id. Defaults to uncleared.
+external_id  | string                          | User-defined external ID for transaction. Max 75 characters. External IDs must be unique within the same asset_id. You may only update this if this transaction was not created from an automatic import, i.e. if this transaction is not associated with a plaid_account_id
+tags         | array of numbers and/or strings | Input must be an array, or error will be thrown. Passing in a number will attempt to match by ID. If no matching tag ID is found, an error will be thrown. Passing in a string will attempt to match by string. If no matching tag name is found, a new tag will be created. Pass in `null` to remove all tags.
 
 ### Split Object
 
-| Key         | Type          | Required | Description                                                                                                                                |
-| ----------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| payee       | string        | false    | Max 140 characters. Sets to original payee if none defined                                                                                 |
-| date        | string        | false    | Must be in ISO 8601 format (YYYY-MM-DD). Sets to original date if none defined                                                             |
-| category_id | number        | false    | Unique identifier for associated category_id. Category must be associated with the same account. Sets to original category if none defined |
-| notes       | string        | false    | Sets to original notes if none defined                                                                                                     |
-| amount      | number/string | true     | Individual amount of split. Currency will inherit from parent transaction. All amounts must sum up to parent transaction amount.           |
+Key         | Type          | Required | Description
+----------- | ------------- | -------- | -------------------------------------------------------------------------------
+payee       | string        | false    | Max 140 characters. Sets to original payee if none defined
+date        | string        | false    | Must be in ISO 8601 format (YYYY-MM-DD). Sets to original date if none defined
+category_id | number        | false    | Unique identifier for associated category_id. Category must be associated with the same account. Sets to original category if none defined
+notes       | string        | false    | Sets to original notes if none defined
+amount      | number/string | true     | Individual amount of split. Currency will inherit from parent transaction. All amounts must sum up to parent transaction amount.
 
 ## Unsplit Transactions
 
@@ -438,10 +468,10 @@ Returns an array of IDs of deleted transactions
 
 ### Body Parameters
 
-| Parameter      | Type             | Required | Default | Description                                                                                              |
-| -------------- | ---------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------- |
-| parent_ids     | array of numbers | true     | -       | Array of transaction IDs to unsplit. If one transaction is unsplittable, no transaction will be unsplit. |
-| remove_parents | boolean          | false    | false   | If true, deletes the original parent transaction as well. Note, this is unreversable!                    |
+Parameter      | Type             | Required | Default | Description
+-------------- | ---------------- | -------- | ------- | ---------------------------------------------------------------
+parent_ids     | array of numbers | true     | -       | Array of transaction IDs to unsplit. If one transaction is unsplittable, no transaction will be unsplit.
+remove_parents | boolean          | false    | false   | If true, deletes the original parent transaction as well. Note, this is unreversable!
 
 ## Get Transaction Group
 
@@ -546,9 +576,9 @@ Returns the hydrated parent transaction of a transaction group
 
 ### Query Parameters
 
-| Parameter      | Type   | Required | Description                                                                         |
-| -------------- | ------ | -------- | ----------------------------------------------------------------------------------- |
-| transaction_id | number | true     | Transaction ID of either the parent or any of the children in the transaction group |
+Parameter      | Type   | Required | Description
+-------------- | ------ | -------- | -----------------------------------------------------------------------------------
+transaction_id | number | true     | Transaction ID of either the parent or any of the children in the transaction group
 
 ## Create Transaction Group
 
@@ -578,14 +608,14 @@ Returns the ID of the newly created transaction group
 
 ### Body Parameters
 
-| Parameter    | Type   | Required | Default | Description                                                  |
-| ------------ | ------ | -------- | ------- | ------------------------------------------------------------ |
-| date         | string | true     | -       | Date for the grouped transaction                             |
-| payee        | string | true     | -       | Payee name for the grouped transaction                       |
-| category_id  | number | false    | -       | Category for the grouped transaction                         |
-| notes        | string | false    | -       | Notes for the grouped transaction                            |
-| tags         | array  | false    | -       | Array of tag IDs for the grouped transaction                 |
-| transactions | array  | true     | -       | Array of transaction IDs to be part of the transaction group |
+Parameter    | Type   | Required | Default | Description
+------------ | ------ | -------- | ------- | ------------------------------------------------------------
+date         | string | true     | -       | Date for the grouped transaction
+payee        | string | true     | -       | Payee name for the grouped transaction
+category_id  | number | false    | -       | Category for the grouped transaction
+notes        | string | false    | -       | Notes for the grouped transaction
+tags         | array  | false    | -       | Array of tag IDs for the grouped transaction
+transactions | array  | true     | -       | Array of transaction IDs to be part of the transaction group
 
 ## Delete Transaction Group
 


### PR DESCRIPTION
Part of https://github.com/lunch-money/developers/issues/29 adding the nullable column to the transaction object.

Some other small tweaks while I was in here:
- dropped leading and trailing pipes from all table markdown to avoid needing extra spaces and lines. This greatly improves readability when editing, but makes no change to the user facing side.
- Specified on update transaction that split expects an array of split objects
- added `see description` to the required portion of split and transaction on update transaction, since only one of them is required at a time
- added tag and children to the transaction example