### PR TITLE
clean leading/trailing spaces from assets table

### DIFF
--- a/source/includes/_assets.md
+++ b/source/includes/_assets.md
@@ -2,20 +2,20 @@
 
 ## Assets Object
 
-| Attribute Name       | Type    | Nullable | Description                                                                                                                                                                                                                          |
-| -------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| id                   | number  | false    | Unique identifier for asset                                                                                                                                                                                                          |
-| type_name            | string  | false    | Primary type of the asset. Must be one of:<br><ul> <li>cash</li> <li>credit</li> <li>investment</li> <li>real estate</li> <li>loan</li> <li>vehicle</li> <li>cryptocurrency</li> <li>employee compensation</li> <li>other liability</li> <li>other asset</li> </ul> |
-| subtype_name         | string  | true     | Optional asset subtype. Examples include:<br><ul> <li>retirement</li> <li>checking</li> <li>savings</li> <li>prepaid credit card</li><ul>                                                                                            |
-| name                 | string  | false    | Name of the asset                                                                                                                                                                                                                    |
-| display_name         | string  | true     | Display name of the asset (as set by user)                                                                                                                                                                                           |
-| balance              | string  | false    | Current balance of the asset in numeric format to 4 decimal places                                                                                                                                                                   |
-| balance_as_of        | string  | false    | Date/time the balance was last updated in ISO 8601 extended format                                                                                                                                                                   |
-| closed_on            | string  | true     | The date this asset was closed (optional)                                                                                                                                                                                            |
-| currency             | string  | false    | Three-letter lowercase currency code of the balance in ISO 4217 format                                                                                                                                                               |
-| institution_name     | string  | true     | Name of institution holding the asset                                                                                                                                                                                                |
-| exclude_transactions | boolean | false    | If true, this asset will not show up as an option for assignment when creating transactions manually                                                                                                                                 |
-| created_at           | string  | false    | Date/time the asset was created in ISO 8601 extended format                                                                                                                                                                          |
+Attribute Name       | Type    | Nullable | Description
+-------------------- | ------- | -------- | ----------------------------------------------------------------------------
+id                   | number  | false    | Unique identifier for asset
+type_name            | string  | false    | Primary type of the asset. Must be one of:<br><ul> <li>cash</li> <li>credit</li> <li>investment</li> <li>real estate</li> <li>loan</li> <li>vehicle</li> <li>cryptocurrency</li> <li>employee compensation</li> <li>other liability</li> <li>other asset</li> </ul> |
+subtype_name         | string  | true     | Optional asset subtype. Examples include:<br><ul> <li>retirement</li> <li>checking</li> <li>savings</li> <li>prepaid credit card</li><ul>
+name                 | string  | false    | Name of the asset
+display_name         | string  | true     | Display name of the asset (as set by user)
+balance              | string  | false    | Current balance of the asset in numeric format to 4 decimal places
+balance_as_of        | string  | false    | Date/time the balance was last updated in ISO 8601 extended format
+closed_on            | string  | true     | The date this asset was closed (optional)
+currency             | string  | false    | Three-letter lowercase currency code of the balance in ISO 4217 format
+institution_name     | string  | true     | Name of institution holding the asset
+exclude_transactions | boolean | false    | If true, this asset will not show up as an option for assignment when creating transactions manually
+created_at           | string  | false    | Date/time the asset was created in ISO 8601 extended format
 
 ## Get All Assets
 
@@ -111,18 +111,18 @@ Use this endpoint to create a single (manually-managed) asset.
 
 ### Body Parameters
 
-| Parameter            | Type    | Required | Default                 | Description                                                                                                                                      |
-| -------------------- | ------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| type_name            | string  | true     | -                       | Must be one of: cash, credit, investment, other, real estate, loan, vehicle, cryptocurrency, employee compensation                               |
-| subtype_name         | string  | false    | -                       | Max 25 characters                                                                                                                                |
-| name                 | string  | true     | -                       | Max 45 characters                                                                                                                                |
-| display_name         | string  | false    | -                       | Display name of the asset (as set by user)                                                                                                       |
-| balance              | string  | true     | -                       | Numeric value of the current balance of the account. Do not include any special characters aside from a decimal point!                           |
-| balance_as_of        | string  | false    | Current timestamp       | Has no effect if balance is not defined. If balance is defined, but balance_as_of is not supplied or is invalid, current timestamp will be used. |
-| currency             | string  | false    | User's primary currency | Three-letter lowercase currency in ISO 4217 format. The code sent must exist in our database. Defaults to user's primary currency.               |
-| institution_name     | string  | false    | -                       | Max 50 characters                                                                                                                                |
-| closed_on            | string  | false    | -                       | The date this asset was closed                                                                                                                   |
-| exclude_transactions | boolean | false    | false                   | If true, this asset will not show up as an option for assignment when creating transactions manually                                             |
+Parameter            | Type    | Required | Default                 | Description
+-------------------- | ------- | -------- | ----------------------- | --------------------------------------------------
+type_name            | string  | true     | -                       | Must be one of: cash, credit, investment, other, real estate, loan, vehicle, cryptocurrency, employee compensation
+subtype_name         | string  | false    | -                       | Max 25 characters
+name                 | string  | true     | -                       | Max 45 characters
+display_name         | string  | false    | -                       | Display name of the asset (as set by user)
+balance              | string  | true     | -                       | Numeric value of the current balance of the account. Do not include any special characters aside from a decimal point!
+balance_as_of        | string  | false    | Current timestamp       | Has no effect if balance is not defined. If balance is defined, but balance_as_of is not supplied or is invalid, current timestamp will be used.
+currency             | string  | false    | User's primary currency | Three-letter lowercase currency in ISO 4217 format. The code sent must exist in our database. Defaults to user's primary currency.
+institution_name     | string  | false    | -                       | Max 50 characters
+closed_on            | string  | false    | -                       | The date this asset was closed
+exclude_transactions | boolean | false    | false                   | If true, this asset will not show up as an option for assignment when creating transactions manually
 
 ## Update Asset
 
@@ -161,17 +161,17 @@ Use this endpoint to update a single asset.
 
 ### Body Parameters
 
-| Parameter            | Type    | Required | Default                 | Description                                                                                                                                      |
-| -------------------- | ------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| type_name            | string  | false    | -                       | Must be one of: cash, credit, investment, other, real estate, loan, vehicle, cryptocurrency, employee compensation                               |
-| subtype_name         | string  | false    | -                       | Max 25 characters                                                                                                                                |
-| name                 | string  | false    | -                       | Max 45 characters                                                                                                                                |
-| display_name         | string  | false    | -                       | Display name of the asset (as set by user)                                                                                                       |
-| balance              | string  | false    | -                       | Numeric value of the current balance of the account. Do not include any special characters aside from a decimal point!                           |
-| balance_as_of        | string  | false    | Current timestamp       | Has no effect if balance is not defined. If balance is defined, but balance_as_of is not supplied or is invalid, current timestamp will be used. |
-| currency             | string  | false    | User's primary currency | Three-letter lowercase currency in ISO 4217 format. The code sent must exist in our database. Defaults to user's primary currency.               |
-| institution_name     | string  | false    | -                       | Max 50 characters                                                                                                                                |
-| closed_on            | string  | false    | -                       | The date this asset was closed                                                                                                                   |
-| exclude_transactions | boolean | false    | false                   | If true, this asset will not show up as an option for assignment when creating transactions manually                                             |
+Parameter            | Type    | Required | Default                 | Description
+-------------------- | ------- | -------- | ----------------------- | --------------------------------------------------
+type_name            | string  | false    | -                       | Must be one of: cash, credit, investment, other, real estate, loan, vehicle, cryptocurrency, employee compensation
+subtype_name         | string  | false    | -                       | Max 25 characters
+name                 | string  | false    | -                       | Max 45 characters
+display_name         | string  | false    | -                       | Display name of the asset (as set by user)
+balance              | string  | false    | -                       | Numeric value of the current balance of the account. Do not include any special characters aside from a decimal point!
+balance_as_of        | string  | false    | Current timestamp       | Has no effect if balance is not defined. If balance is defined, but balance_as_of is not supplied or is invalid, current timestamp will be used.
+currency             | string  | false    | User's primary currency | Three-letter lowercase currency in ISO 4217 format. The code sent must exist in our database. Defaults to user's primary currency.
+institution_name     | string  | false    | -                       | Max 50 characters
+closed_on            | string  | false    | -                       | The date this asset was closed
+exclude_transactions | boolean | false    | false                   | If true, this asset will not show up as an option for assignment when creating transactions manually
 
 ---


### PR DESCRIPTION
Following the other PRs, making this page consistent and removing the trailing/leading pipes from the table markdown, making things cleaner to read when editing