### PR TITLE
fix get transaction group to be GET instead of POST

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -542,7 +542,7 @@ Returns the hydrated parent transaction of a transaction group
 
 ### HTTP Request
 
-`POST https://dev.lunchmoney.app/v1/transactions/group`
+`GET https://dev.lunchmoney.app/v1/transactions/group`
 
 ### Query Parameters
 


### PR DESCRIPTION
This was likely a copy and paste error when added, just noticed it was labelled incorrectly.