### PR TITLE
add to_base to crypto object and add nullable column

### DIFF
--- a/source/includes/_crypto.md
+++ b/source/includes/_crypto.md
@@ -1,21 +1,24 @@
 # Crypto
 
 ## Crypto Object
-Attribute Name      | Type   | Description
-------------------- | ----   | -----------
-id                  | number | Unique identifier for a manual crypto account (no ID for synced accounts)
-zabo_account_id     | number | Unique identifier for a synced crypto account (no ID for manual accounts, multiple currencies may have the same zabo_account_id)
-source              | string | One of:<br/><ul><li>`synced`: this account is synced via a wallet, exchange, etc.</li><li>`manual`: this account balance is managed manually</li></ul>
-name                | string | Name of the crypto asset
-display_name        | string | Display name of the crypto asset (as set by user)
-balance             | string | Current balance
-balance_as_of       | string | Date/time the balance was last updated in ISO 8601 extended format
-currency            | string | Abbreviation for the cryptocurrency
-status              | string | The current status of the crypto account. Either active or in error.
-institution_name    | string | Name of provider holding the asset
-created_at          | string | Date/time the asset was created in ISO 8601 extended format
+
+Attribute Name      | Type   | Nullable | Description
+------------------- | ----   | -------- | -----------
+id                  | number | true     | Unique identifier for a manual crypto account (no ID for synced accounts)
+zabo_account_id     | number | true     | Unique identifier for a synced crypto account (no ID for manual accounts, multiple currencies may have the same zabo_account_id)
+source              | string | false    | One of:<br/><ul><li>`synced`: this account is synced via a wallet, exchange, etc.</li><li>`manual`: this account balance is managed manually</li></ul>
+name                | string | false    | Name of the crypto asset
+display_name        | string | true     | Display name of the crypto asset (as set by user)
+balance             | string | false    | Current balance
+balance_as_of       | string | false    | Date/time the balance was last updated in ISO 8601 extended format
+currency            | string | false    | Abbreviation for the cryptocurrency
+status              | string | false    | The current status of the crypto account. Either active or in error.
+institution_name    | string | true     | Name of provider holding the asset
+created_at          | string | false    | Date/time the asset was created in ISO 8601 extended format
+to_base             | number | true     | The balance converted to the user's primary currency.
 
 ## Get All Crypto
+
 Use this endpoint to get a list of all cryptocurrency assets associated with the user's account. Both crypto balances from synced and manual accounts will be returned.
 
 > Example 200 Response
@@ -86,6 +89,7 @@ Use this endpoint to update a single manually-managed crypto asset (does not inc
 `PUT https://dev.lunchmoney.app/v1/crypto/manual/:id`
 
 ### Body Parameters
+
 Parameter        | Type   | Required | Default | Description
 ---------        | ----   | -------- | ------- | -----------
 name             | string | false    | -       | Official or full name of the account. Max 45 characters


### PR DESCRIPTION
This adds the new `to_base` attribute that started showing up on some crypto objects to the docs as well as adds the nullable column and resolves https://github.com/lunch-money/developers/issues/29 (I didn't realize I had missed adding the column for this object)