### PR TITLE
Document 500 Transaction limit per POST requests

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -314,7 +314,7 @@ Returns a single Transaction object
 
 ## Insert Transactions
 
-Use this endpoint to insert many transactions at once.
+Use this endpoint to insert one or more transactions at once.   The maximum number of transactions per requests is 500.
 
 > Example 200 Response
 >


### PR DESCRIPTION
After reading the code, I can see that the API will return an error if someone tries to insert more than 500 transactions in a single POST /transactions request.