### PR TITLE
Add plaid_account_id to Transaction Insert Object

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+    "cSpell.words": [
+        "budgetable",
+        "bunq",
+        "counterparties",
+        "deduping",
+        "Dogecoin",
+        "fakecoin",
+        "Frelard",
+        "Geico",
+        "joehoyle",
+        "Kfypky",
+        "markjongkind",
+        "Monzo",
+        "multicurrency",
+        "Qmjdk",
+        "samwelnella",
+        "SHIB",
+        "Shiba",
+        "Uncategorized",
+        "Unsplit",
+        "unsplittable",
+        "Upsert",
+        "Venmo",
+        "YOURACCESSTOKEN",
+        "zabo"
+    ]
+}

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,28 @@
+{
+  "words": [
+    "budgetable",
+    "bunq",
+    "counterparties",
+    "deduping",
+    "Dogecoin",
+    "fakecoin",
+    "Frelard",
+    "Geico",
+    "joehoyle",
+    "Kfypky",
+    "markjongkind",
+    "Monzo",
+    "multicurrency",
+    "Qmjdk",
+    "samwelnella",
+    "SHIB",
+    "Shiba",
+    "Uncategorized",
+    "Unsplit",
+    "unsplittable",
+    "Upsert",
+    "Venmo",
+    "YOURACCESSTOKEN",
+    "zabo"
+  ]
+}

--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,7 +2,7 @@
 
 A log of changes. Breaking changes will be denoted with 🚨
 ## Dec 20, 2024
-- The [Transaction Insert Object](#Transaction-Object-to-Insert) now accepts a `plaid_account_id` allowing developers to update or modify transactions associated with plaid accounts if the "Allow Modifications to Transactions" property is set.
+- The [Transaction Insert Object](#transaction-object-to-insert) now accepts a `plaid_account_id` allowing developers to update or modify transactions associated with plaid accounts if the "Allow Modifications to Transactions" property is set.
 - The bug that prevented users from inserting transactions with the same `asset_id`/`external_id` as a previously deleted transaction has been fixed.
 
 ## June 15, 2024

--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
 A log of changes. Breaking changes will be denoted with 🚨
+## Dec 20, 2024
+- The [Transaction Insert Object](#Transaction-Object-to-Insert) now accepts a `plaid_account_id` allowing developers to update or modify transactions associated with plaid accounts if the "Allow Modifications to Transactions" property is set.
+- The bug that prevented users from inserting transactions with the same `asset_id`/`external_id` as a previously deleted transaction has been fixed.
 
 ## June 15, 2024
 - New endpoint: [GET /v1/recurring_items](#get-recurring-items)

--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -335,7 +335,7 @@ Use this endpoint to insert one or more transactions at once.   The maximum numb
   "error": [
     "Transaction 0 is missing date.",
     "Transaction 0 is missing amount.",
-    "Transaction 1 status must be either cleared or uncleared: null" 
+    "Transaction 1 status must be either cleared or uncleared: null"
   ]
 }
 ```

--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -335,7 +335,7 @@ Use this endpoint to insert one or more transactions at once.   The maximum numb
   "error": [
     "Transaction 0 is missing date.",
     "Transaction 0 is missing amount.",
-    "Transaction 1 status must be either cleared or uncleared: null"
+    "Transaction 1 status must be either cleared or uncleared: null" 
   ]
 }
 ```
@@ -357,19 +357,20 @@ Use this endpoint to insert one or more transactions at once.   The maximum numb
 
 ### Transaction Object to Insert
 
-| Key          | Type                            | Required | Description                                                                                                                                                                                                                 |
-| ------------ | ------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| date         | string                          | true     | Must be in ISO 8601 format (YYYY-MM-DD).                                                                                                                                                                                    |
-| amount       | number/string                   | true     | Numeric value of amount. i.e. $4.25 should be denoted as 4.25.                                                                                                                                                              |
-| category_id  | number                          | false    | Unique identifier for associated category_id. Category must be associated with the same account and must not be a category group.                                                                                           |
-| payee        | string                          | false    | Max 140 characters                                                                                                                                                                                                          |
-| currency     | string                          | false    | Three-letter lowercase currency code in ISO 4217 format. The code sent must exist in our database. Defaults to user account's primary currency.                                                                             |
-| asset_id     | number                          | false    | Unique identifier for associated asset (manually-managed account). Asset must be associated with the same account.                                                                                                          |
-| recurring_id | number                          | false    | Unique identifier for associated recurring expense. Recurring expense must be associated with the same account.                                                                                                             |
-| notes        | string                          | false    | Max 350 characters                                                                                                                                                                                                          |
-| status       | string                          | false    | Must be either cleared or uncleared. (Note: special statuses for recurring items have been deprecated.) Defaults to uncleared.                                                                                              |
-| external_id  | string                          | false    | User-defined external ID for transaction. Max 75 characters. External IDs must be unique within the same asset_id.                                                                                                          |
-| tags         | Array of numbers and/or strings | false    | Passing in a number will attempt to match by ID. If no matching tag ID is found, an error will be thrown. Passing in a string will attempt to match by string. If no matching tag name is found, a new tag will be created. |
+| Key             | Type                            | Required | Description                                                                                                                                                                                                                 |
+|-----------------|---------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| date            | string                          | true     | Must be in ISO 8601 format (YYYY-MM-DD).                                                                                                                                                                                    |
+| amount          | number/string                   | true     | Numeric value of amount. i.e. $4.25 should be denoted as 4.25.                                                                                                                                                              |
+| category_id     | number                          | false    | Unique identifier for associated category_id. Category must be associated with the same account and must not be a category group.                                                                                           |
+| payee           | string                          | false    | Max 140 characters                                                                                                                                                                                                          |
+| currency        | string                          | false    | Three-letter lowercase currency code in ISO 4217 format. The code sent must exist in our database. Defaults to user account's primary currency.                                                                             |
+| asset_id        | number                          | false    | Unique identifier for associated asset (manually-managed account). Asset must be associated with the same account. When set `plaid_account_id` may not be set.                                                                |
+| plaid_account_id| number                          | false    | Unique identifier for associated plaid account. This must have the "Allow Modifications to Transactions" option set. When set `asset_id` may not be set.                                                                      |
+| recurring_id    | number                          | false    | Unique identifier for associated recurring expense. Recurring expense must be associated with the same account.                                                                                                             |
+| notes           | string                          | false    | Max 350 characters                                                                                                                                                                                                          |
+| status          | string                          | false    | Must be either cleared or uncleared. (Note: special statuses for recurring items have been deprecated.) Defaults to uncleared.                                                                                              |
+| external_id     | string                          | false    | User-defined external ID for transaction. Max 75 characters. External IDs must be unique within the same asset_id.                                                                                                          |
+| tags            | Array of numbers and/or strings | false    | Passing in a number will attempt to match by ID. If no matching tag ID is found, an error will be thrown. Passing in a string will attempt to match by string. If no matching tag name is found, a new tag will be created. |
 
 ## Update Transaction
 


### PR DESCRIPTION
Document ability to set plaid_account_id on the Transaction Insert Object